### PR TITLE
docs: fix Linux installation command and add missing newline

### DIFF
--- a/Technology/Linux/Arch Linux.md
+++ b/Technology/Linux/Arch Linux.md
@@ -9,6 +9,6 @@
 
 1. `sudo pacman -Syu`: upgrade packages
 2. `sudo pacman -S --needed git base-devel`
-3. `git clone "AUR-repo-link"`
-4. `cd <repo-dir>`
-5. `makepkg -si`
+3. `git clone "AUR-repo-link"`: Clone the AUR repository.
+4. `cd <repo-dir>`: Change into the repository's directory.
+5. `makepkg -si`: Build the package, resolve dependencies, and install it.

--- a/Technology/Linux/Arch Linux.md
+++ b/Technology/Linux/Arch Linux.md
@@ -1,4 +1,3 @@
-
 ## Installation Guide:
 
 1. `pacman -Sy`: Synchronize with the package database.
@@ -10,4 +9,6 @@
 
 1. `sudo pacman -Syu`: upgrade packages
 2. `sudo pacman -S --needed git base-devel`
-3. `sudo git clone "AUR-repo-link"`
+3. `git clone "AUR-repo-link"`
+4. `cd <repo-dir>`
+5. `makepkg -si`


### PR DESCRIPTION
This PR fixes issues in the Linux installation guide:

- Removed `sudo` from the `git clone` command to avoid root-owned files.
- Added `cd <repo-dir>` and `makepkg -si` as the correct Arch workflow for building/installing from AUR.
- Ensured the file ends with a newline for better compatibility with CLI tools.

These changes improve documentation accuracy and follow best practices.